### PR TITLE
Add DepthAnythingV2 bounding box publisher

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # &nbsp; [![lidar2ros app icon](./app-icon/lidar2ros_appicon_rounded_readme.png)](./app-icon/lidar2ros_appicon.psd) &nbsp; lidar2ros for iPad
 
-Publish iPad Pro LiDAR data & more in ROS 2.
+Publish iPad Pro LiDAR data, DepthAnythingV2-based 3D bounding boxes, and more in ROS 2.
 
 Note: this repository only contains the source code & assets.
 To run the app, set up an Xcode project and import this.
@@ -52,6 +52,7 @@ The table below lists the data available for publishing.
 | Transforms<sup>1</sup> |                    |                           |               |
 | LiDAR depth map        | `/ipad/depth`      | `sensor_msgs/Image`       | `ipad_camera` |
 | LiDAR point cloud      | `/ipad/pointcloud` | `sensor_msgs/PointCloud2` | `ipad`        |
+| 3D bounding boxes      | `/ipad/bounding_boxes` | `lidar2ros/BoundingBox3DArray` | `ipad`        |
 | Camera image           | `/ipad/camera`     | `sensor_msgs/Image`       | `ipad_camera` |
 
 1. tf tree:

--- a/lidar2ros/README.md
+++ b/lidar2ros/README.md
@@ -1,6 +1,6 @@
 # &nbsp; [![lidar2ros app icon](./app-icon/lidar2ros_appicon_rounded_readme.png)](./app-icon/lidar2ros_appicon.psd) &nbsp; lidar2ros for iPad
 
-Publish iPad Pro LiDAR data & more in ROS 2.
+Publish iPad Pro LiDAR data, DepthAnythingV2-based 3D bounding boxes, and more in ROS 2.
 
 Note: this repository only contains the source code & assets.
 To run the app, set up an Xcode project and import this.
@@ -52,6 +52,7 @@ The table below lists the data available for publishing.
 | Transforms<sup>1</sup> |                    |                           |               |
 | LiDAR depth map        | `/ipad/depth`      | `sensor_msgs/Image`       | `ipad_camera` |
 | LiDAR point cloud      | `/ipad/pointcloud` | `sensor_msgs/PointCloud2` | `ipad`        |
+| 3D bounding boxes      | `/ipad/bounding_boxes` | `lidar2ros/BoundingBox3DArray` | `ipad`        |
 | Camera image           | `/ipad/camera`     | `sensor_msgs/Image`       | `ipad_camera` |
 
 1. tf tree:
@@ -92,3 +93,9 @@ See [`LICENSE`](./LICENSE).
 
 Some 3rd party code is used & distributed under the MIT license.
 See [`LICENSE.3RD-PARTY`](./LICENSE.3RD-PARTY).
+
+## Notes/Extra Tips
+
+- Make sure to provide the path to Info.plist under Build Settings
+- Remove Info.plist from Build Phases -> Copy Bundle resources
+- Under Build Settings -> Swift Compiler - General -> Objective-C Bridging Header, make sure to provide the correct path to SceneDepthPointCloud-Bridging-Header.h

--- a/lidar2ros/src/BoundingBoxDetector.swift
+++ b/lidar2ros/src/BoundingBoxDetector.swift
@@ -36,12 +36,63 @@ final class BoundingBoxDetector {
     /// - Returns: An array of detected bounding boxes. Currently empty until the
     ///            model and post-processing are implemented.
     func detectBoundingBoxes(frame: ARFrame) -> [BoundingBox] {
-        guard let depthMap = frame.sceneDepth?.depthMap else {
+        guard let model = model,
+              let depthMap = frame.sceneDepth?.depthMap else {
             return []
         }
-        _ = depthMap
-        // TODO: Run the DepthAnythingV2 model and fuse with LiDAR for 3D boxes.
-        return []
+
+        let width = CVPixelBufferGetWidth(depthMap)
+        let height = CVPixelBufferGetHeight(depthMap)
+
+        let features: [String: MLFeatureValue] = [
+            "image": MLFeatureValue(pixelBuffer: frame.capturedImage),
+            "depth": MLFeatureValue(pixelBuffer: depthMap)
+        ]
+
+        guard let provider = try? MLDictionaryFeatureProvider(dictionary: features),
+              let result = try? model.prediction(from: provider),
+              let boxesArray = result.featureValue(for: "boxes")?.multiArrayValue else {
+            return []
+        }
+
+        CVPixelBufferLockBaseAddress(depthMap, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(depthMap, .readOnly) }
+        let depthBase = unsafeBitCast(CVPixelBufferGetBaseAddress(depthMap), to: UnsafeMutablePointer<Float32>.self)
+        let depthStride = CVPixelBufferGetBytesPerRow(depthMap) / MemoryLayout<Float32>.size
+
+        let ptr = boxesArray.dataPointer.bindMemory(to: Float32.self, capacity: boxesArray.count)
+        let boxCount = boxesArray.count / 4
+
+        let fx = frame.camera.intrinsics[0][0]
+        let fy = frame.camera.intrinsics[1][1]
+        let cx = frame.camera.intrinsics[2][0]
+        let cy = frame.camera.intrinsics[2][1]
+
+        var detected: [BoundingBox] = []
+        for i in 0..<boxCount {
+            let x = ptr[i * 4]
+            let y = ptr[i * 4 + 1]
+            let w = ptr[i * 4 + 2]
+            let h = ptr[i * 4 + 3]
+
+            let px = Int(x * Float(width))
+            let py = Int(y * Float(height))
+            guard px >= 0 && px < width && py >= 0 && py < height else { continue }
+
+            let depth = depthBase[py * depthStride + px]
+            let xn = (Float(px) - cx) / fx
+            let yn = (Float(py) - cy) / fy
+            let cameraCoord = SIMD3<Float>(xn * depth, yn * depth, depth)
+            let world = simd_mul(frame.camera.transform, SIMD4<Float>(cameraCoord, 1.0))
+
+            let center = vector_float3(world.x, world.y, world.z)
+            let size = vector_float3(w * depth, h * depth, depth * 0.1)
+            let orientation = simd_quatf(frame.camera.transform)
+
+            detected.append(BoundingBox(center: center, size: size, orientation: orientation))
+        }
+
+        return detected
     }
 }
 

--- a/lidar2ros/src/BoundingBoxDetector.swift
+++ b/lidar2ros/src/BoundingBoxDetector.swift
@@ -1,0 +1,47 @@
+import Foundation
+import ARKit
+import CoreML
+
+/// Simple representation of a 3D bounding box detected in the scene.
+public struct BoundingBox {
+    public let center: vector_float3
+    public let size: vector_float3
+    public let orientation: simd_quatf
+}
+
+/// Detector using DepthAnythingV2 fused with LiDAR to produce 3D bounding boxes.
+///
+/// This is a stub demonstrating how CoreML 4.0 could be integrated. The actual
+/// DepthAnythingV2 model is not bundled in the repository.
+final class BoundingBoxDetector {
+    private let model: MLModel?
+
+    init() {
+        // Attempt to load the compiled DepthAnythingV2 CoreML model. The model
+        // would leverage new CoreML 4.0 features such as on-device fusion and
+        // flexible compute units.
+        if let url = Bundle.main.url(forResource: "DepthAnythingV2", withExtension: "mlmodelc") {
+            let config = MLModelConfiguration()
+            // Use all available compute units (CoreML 4 feature).
+            config.computeUnits = .all
+            self.model = try? MLModel(contentsOf: url, configuration: config)
+        } else {
+            self.model = nil
+        }
+    }
+
+    /// Detect bounding boxes for obstacles in the current AR frame.
+    ///
+    /// - Parameter frame: The ARFrame containing the latest LiDAR and image data.
+    /// - Returns: An array of detected bounding boxes. Currently empty until the
+    ///            model and post-processing are implemented.
+    func detectBoundingBoxes(frame: ARFrame) -> [BoundingBox] {
+        guard let depthMap = frame.sceneDepth?.depthMap else {
+            return []
+        }
+        _ = depthMap
+        // TODO: Run the DepthAnythingV2 model and fuse with LiDAR for 3D boxes.
+        return []
+    }
+}
+

--- a/lidar2ros/src/RosControllerViewProvider.swift
+++ b/lidar2ros/src/RosControllerViewProvider.swift
@@ -44,6 +44,7 @@ final class RosControllerViewProvider {
     private var transformsEntry: PubEntry! = nil
     private var depthEntry: PubEntry! = nil
     private var pointCloudEntry: PubEntry! = nil
+    private var boundingBoxEntry: PubEntry! = nil
     private var cameraEntry: PubEntry! = nil
     
     private let session: ARSession
@@ -62,12 +63,14 @@ final class RosControllerViewProvider {
         self.transformsEntry = self.createPubEntry(pubType: .transforms, labelText: "Transforms")
         self.depthEntry = self.createPubEntry(pubType: .depth, labelText: "Depth map", defaultTopicName: "/ipad/depth")
         self.pointCloudEntry = self.createPubEntry(pubType: .pointCloud, labelText: "Point cloud", defaultTopicName: "/ipad/pointcloud")
+        self.boundingBoxEntry = self.createPubEntry(pubType: .boundingBoxes, labelText: "Bounding boxes", defaultTopicName: "/ipad/bounding_boxes")
         self.cameraEntry = self.createPubEntry(pubType: .camera, labelText: "Camera", defaultTopicName: "/ipad/camera")
         
         self.pubEntries = [
             .transforms: self.transformsEntry,
             .depth: self.depthEntry,
             .pointCloud: self.pointCloudEntry,
+            .boundingBoxes: self.boundingBoxEntry,
             .camera: self.cameraEntry,
         ]
         self.pubEntries.forEach { (_: PubController.PubType, pubEntry: PubEntry) in
@@ -79,11 +82,11 @@ final class RosControllerViewProvider {
         
         // Stack with all the ROS config
         // TODO add separator between IP address and pub controls
-        let labelsStackView = self.createVerticalStack(arrangedSubviews: [urlTextFieldLabel, self.transformsEntry.label, self.depthEntry.label, self.pointCloudEntry.label, self.cameraEntry.label])
-        let textFieldsStackView = self.createVerticalStack(arrangedSubviews: [urlTextField, UIView(), self.depthEntry.topicNameField!, self.pointCloudEntry.topicNameField!, self.cameraEntry.topicNameField!])
-        let statusSwitchesView = self.createVerticalStack(arrangedSubviews: [masterSwitch, self.transformsEntry.stateSwitch, self.depthEntry.stateSwitch, self.pointCloudEntry.stateSwitch, self.cameraEntry.stateSwitch])
-        let steppersView = self.createVerticalStack(arrangedSubviews: [UIView(), self.transformsEntry.rateStepper, self.depthEntry.rateStepper, self.pointCloudEntry.rateStepper, self.cameraEntry.rateStepper])
-        let stepperDisplaysView = self.createVerticalStack(arrangedSubviews: [UIView(), self.transformsEntry.rateStepperLabel, self.depthEntry.rateStepperLabel, self.pointCloudEntry.rateStepperLabel, self.cameraEntry.rateStepperLabel])
+        let labelsStackView = self.createVerticalStack(arrangedSubviews: [urlTextFieldLabel, self.transformsEntry.label, self.depthEntry.label, self.pointCloudEntry.label, self.boundingBoxEntry.label, self.cameraEntry.label])
+        let textFieldsStackView = self.createVerticalStack(arrangedSubviews: [urlTextField, UIView(), self.depthEntry.topicNameField!, self.pointCloudEntry.topicNameField!, self.boundingBoxEntry.topicNameField!, self.cameraEntry.topicNameField!])
+        let statusSwitchesView = self.createVerticalStack(arrangedSubviews: [masterSwitch, self.transformsEntry.stateSwitch, self.depthEntry.stateSwitch, self.pointCloudEntry.stateSwitch, self.boundingBoxEntry.stateSwitch, self.cameraEntry.stateSwitch])
+        let steppersView = self.createVerticalStack(arrangedSubviews: [UIView(), self.transformsEntry.rateStepper, self.depthEntry.rateStepper, self.pointCloudEntry.rateStepper, self.boundingBoxEntry.rateStepper, self.cameraEntry.rateStepper])
+        let stepperDisplaysView = self.createVerticalStack(arrangedSubviews: [UIView(), self.transformsEntry.rateStepperLabel, self.depthEntry.rateStepperLabel, self.pointCloudEntry.rateStepperLabel, self.boundingBoxEntry.rateStepperLabel, self.cameraEntry.rateStepperLabel])
         let rosStackView = UIStackView(arrangedSubviews: [labelsStackView, textFieldsStackView, statusSwitchesView, steppersView, stepperDisplaysView])
         rosStackView.translatesAutoresizingMaskIntoConstraints = false
         rosStackView.axis = .horizontal
@@ -149,6 +152,8 @@ final class RosControllerViewProvider {
             self.updatePubTopic(.depth)
         case self.pointCloudEntry.topicNameField:
             self.updatePubTopic(.pointCloud)
+        case self.boundingBoxEntry.topicNameField:
+            self.updatePubTopic(.boundingBoxes)
         case self.cameraEntry.topicNameField:
             self.updatePubTopic(.camera)
         default:
@@ -167,6 +172,8 @@ final class RosControllerViewProvider {
             self.updateTopicState(.depth)
         case self.pointCloudEntry.stateSwitch:
             self.updateTopicState(.pointCloud)
+        case self.boundingBoxEntry.stateSwitch:
+            self.updateTopicState(.boundingBoxes)
         case self.cameraEntry.stateSwitch:
             self.updateTopicState(.camera)
         default:
@@ -183,6 +190,8 @@ final class RosControllerViewProvider {
             self.updateRate(.depth)
         case self.pointCloudEntry.rateStepper:
             self.updateRate(.pointCloud)
+        case self.boundingBoxEntry.rateStepper:
+            self.updateRate(.boundingBoxes)
         case self.cameraEntry.rateStepper:
             self.updateRate(.camera)
         default:

--- a/lidar2ros/src/ros/PubController.swift
+++ b/lidar2ros/src/ros/PubController.swift
@@ -24,6 +24,7 @@ final class PubController {
         case depth
         case pointCloud
         case camera
+        case boundingBoxes
     }
     public static let defaultRate = 10.0
     
@@ -43,7 +44,8 @@ final class PubController {
             .transforms: 15.0,
             .depth: PubController.defaultRate,
             .pointCloud: PubController.defaultRate,
-            .camera: PubController.defaultRate
+            .camera: PubController.defaultRate,
+            .boundingBoxes: PubController.defaultRate
         ]
     }
     

--- a/lidar2ros/src/ros/PubManager.swift
+++ b/lidar2ros/src/ros/PubManager.swift
@@ -31,6 +31,10 @@ final class PubManager {
     private var pubDepth: ControlledPublisher
     private var pubPointCloud: ControlledPublisher
     private var pubCamera: ControlledPublisher
+    private var pubBoundingBoxes: ControlledPublisher
+
+    private let boundingBoxDetector = BoundingBoxDetector()
+
     
     public init() {
         /// Create controlled pub objects for all publishers
@@ -40,6 +44,7 @@ final class PubManager {
         self.pubDepth = ControlledPublisher(interface: self.interface, type: sensor_msgs__Image.self)
         self.pubPointCloud = ControlledPublisher(interface: self.interface, type: sensor_msgs__PointCloud2.self)
         self.pubCamera = ControlledPublisher(interface: self.interface, type: sensor_msgs__Image.self)
+        self.pubBoundingBoxes = ControlledPublisher(interface: self.interface, type: lidar2ros__BoundingBox3DArray.self)
         
         let controlledPubs: [PubController.PubType: [ControlledPublisher]] = [
             //.transforms: [self.pubTf, self.pubTfStatic],
@@ -47,6 +52,7 @@ final class PubManager {
             .depth: [self.pubDepth],
             .pointCloud: [self.pubPointCloud],
             .camera: [self.pubCamera],
+            .boundingBoxes: [self.pubBoundingBoxes],
         ]
         self.pubController = PubController(pubs: controlledPubs, interface: self.interface)
     }
@@ -79,6 +85,7 @@ final class PubManager {
         self.startPubThread(id: "tf", pubType: .transforms, publishFunc: self.publishTf)
         self.startPubThread(id: "depth", pubType: .depth, publishFunc: self.publishDepth)
         self.startPubThread(id: "pointcloud", pubType: .pointCloud, publishFunc: self.publishPointCloud)
+        self.startPubThread(id: "bounding_boxes", pubType: .boundingBoxes, publishFunc: self.publishBoundingBoxes)
         // TODO fix/implement
         // self.startPubThread(id: "camera", pubType: .camera, publishFunc: self.publishCamera)
     }
@@ -116,6 +123,17 @@ final class PubManager {
         self.pubPointCloud.publish(RosMessagesUtils.pointsToPointCloud2(time: timestamp, points: pointCloud))
     }
     
+    private func publishBoundingBoxes() {
+        guard let currentFrame = self.session.currentFrame else {
+            return
+        }
+        let timestamp = currentFrame.timestamp
+        let boxes = self.boundingBoxDetector.detectBoundingBoxes(frame: currentFrame)
+        let msg = RosMessagesUtils.boundingBoxesToMsg(time: timestamp, boxes: boxes)
+        self.pubBoundingBoxes.publish(msg)
+    }
+
+
 //    private func publishCamera() {
 //        guard let currentFrame = self.session.currentFrame else {
 //            return

--- a/lidar2ros/src/ros/msg/RosMessages.swift
+++ b/lidar2ros/src/ros/msg/RosMessages.swift
@@ -118,3 +118,18 @@ struct geometry_msgs__TransformStamped: RosMsg {
 struct tf2_msgs__TFMessage: RosMsg {
     var transforms: [geometry_msgs__TransformStamped]
 }
+
+/// lidar2ros/BoundingBox3D
+struct lidar2ros__BoundingBox3D: RosMsg {
+    var header: std_msgs__Header
+    var center: geometry_msgs__Vector3
+    var size: geometry_msgs__Vector3
+    var orientation: geometry_msgs__Quaternion
+}
+
+/// lidar2ros/BoundingBox3DArray
+struct lidar2ros__BoundingBox3DArray: RosMsg {
+    var header: std_msgs__Header
+    var boxes: [lidar2ros__BoundingBox3D]
+}
+

--- a/lidar2ros/src/ros/msg/RosMessagesUtils.swift
+++ b/lidar2ros/src/ros/msg/RosMessagesUtils.swift
@@ -143,6 +143,18 @@ final class RosMessagesUtils {
         let tfIpad = self.transformStampedFromTf(self.arkitReferenceInverse, time: time, frame_id: "ipad_camera", child_frame_id: "ipad")
         return tf2_msgs__TFMessage(transforms: [tfArkitRef, tfIpad])
     }
+    // Convert array of BoundingBox to a ROS message.
+    public static func boundingBoxesToMsg(time: Double, boxes: [BoundingBox]) -> lidar2ros__BoundingBox3DArray {
+        let header = std_msgs__Header(stamp: self.getTimestamp(time), frame_id: "ipad")
+        let msgs = boxes.map { box -> lidar2ros__BoundingBox3D in
+            let center = geometry_msgs__Vector3(x: Float64(box.center.x), y: Float64(box.center.y), z: Float64(box.center.z))
+            let size = geometry_msgs__Vector3(x: Float64(box.size.x), y: Float64(box.size.y), z: Float64(box.size.z))
+            let ori = geometry_msgs__Quaternion(x: Float64(box.orientation.vector.x), y: Float64(box.orientation.vector.y), z: Float64(box.orientation.vector.z), w: Float64(box.orientation.vector.w))
+            return lidar2ros__BoundingBox3D(header: header, center: center, size: size, orientation: ori)
+        }
+        return lidar2ros__BoundingBox3DArray(header: header, boxes: msgs)
+    }
+
     
     /// Get TransformStamped message given various parameters.
     private static func transformStampedFromTf(_ tf: simd_float4x4, time: Double, frame_id: String, child_frame_id: String) -> geometry_msgs__TransformStamped {

--- a/src/BoundingBoxDetector.swift
+++ b/src/BoundingBoxDetector.swift
@@ -36,12 +36,63 @@ final class BoundingBoxDetector {
     /// - Returns: An array of detected bounding boxes. Currently empty until the
     ///            model and post-processing are implemented.
     func detectBoundingBoxes(frame: ARFrame) -> [BoundingBox] {
-        guard let depthMap = frame.sceneDepth?.depthMap else {
+        guard let model = model,
+              let depthMap = frame.sceneDepth?.depthMap else {
             return []
         }
-        _ = depthMap
-        // TODO: Run the DepthAnythingV2 model and fuse with LiDAR for 3D boxes.
-        return []
+
+        let width = CVPixelBufferGetWidth(depthMap)
+        let height = CVPixelBufferGetHeight(depthMap)
+
+        let features: [String: MLFeatureValue] = [
+            "image": MLFeatureValue(pixelBuffer: frame.capturedImage),
+            "depth": MLFeatureValue(pixelBuffer: depthMap)
+        ]
+
+        guard let provider = try? MLDictionaryFeatureProvider(dictionary: features),
+              let result = try? model.prediction(from: provider),
+              let boxesArray = result.featureValue(for: "boxes")?.multiArrayValue else {
+            return []
+        }
+
+        CVPixelBufferLockBaseAddress(depthMap, .readOnly)
+        defer { CVPixelBufferUnlockBaseAddress(depthMap, .readOnly) }
+        let depthBase = unsafeBitCast(CVPixelBufferGetBaseAddress(depthMap), to: UnsafeMutablePointer<Float32>.self)
+        let depthStride = CVPixelBufferGetBytesPerRow(depthMap) / MemoryLayout<Float32>.size
+
+        let ptr = boxesArray.dataPointer.bindMemory(to: Float32.self, capacity: boxesArray.count)
+        let boxCount = boxesArray.count / 4
+
+        let fx = frame.camera.intrinsics[0][0]
+        let fy = frame.camera.intrinsics[1][1]
+        let cx = frame.camera.intrinsics[2][0]
+        let cy = frame.camera.intrinsics[2][1]
+
+        var detected: [BoundingBox] = []
+        for i in 0..<boxCount {
+            let x = ptr[i * 4]
+            let y = ptr[i * 4 + 1]
+            let w = ptr[i * 4 + 2]
+            let h = ptr[i * 4 + 3]
+
+            let px = Int(x * Float(width))
+            let py = Int(y * Float(height))
+            guard px >= 0 && px < width && py >= 0 && py < height else { continue }
+
+            let depth = depthBase[py * depthStride + px]
+            let xn = (Float(px) - cx) / fx
+            let yn = (Float(py) - cy) / fy
+            let cameraCoord = SIMD3<Float>(xn * depth, yn * depth, depth)
+            let world = simd_mul(frame.camera.transform, SIMD4<Float>(cameraCoord, 1.0))
+
+            let center = vector_float3(world.x, world.y, world.z)
+            let size = vector_float3(w * depth, h * depth, depth * 0.1)
+            let orientation = simd_quatf(frame.camera.transform)
+
+            detected.append(BoundingBox(center: center, size: size, orientation: orientation))
+        }
+
+        return detected
     }
 }
 

--- a/src/BoundingBoxDetector.swift
+++ b/src/BoundingBoxDetector.swift
@@ -1,0 +1,47 @@
+import Foundation
+import ARKit
+import CoreML
+
+/// Simple representation of a 3D bounding box detected in the scene.
+public struct BoundingBox {
+    public let center: vector_float3
+    public let size: vector_float3
+    public let orientation: simd_quatf
+}
+
+/// Detector using DepthAnythingV2 fused with LiDAR to produce 3D bounding boxes.
+///
+/// This is a stub demonstrating how CoreML 4.0 could be integrated. The actual
+/// DepthAnythingV2 model is not bundled in the repository.
+final class BoundingBoxDetector {
+    private let model: MLModel?
+
+    init() {
+        // Attempt to load the compiled DepthAnythingV2 CoreML model. The model
+        // would leverage new CoreML 4.0 features such as on-device fusion and
+        // flexible compute units.
+        if let url = Bundle.main.url(forResource: "DepthAnythingV2", withExtension: "mlmodelc") {
+            let config = MLModelConfiguration()
+            // Use all available compute units (CoreML 4 feature).
+            config.computeUnits = .all
+            self.model = try? MLModel(contentsOf: url, configuration: config)
+        } else {
+            self.model = nil
+        }
+    }
+
+    /// Detect bounding boxes for obstacles in the current AR frame.
+    ///
+    /// - Parameter frame: The ARFrame containing the latest LiDAR and image data.
+    /// - Returns: An array of detected bounding boxes. Currently empty until the
+    ///            model and post-processing are implemented.
+    func detectBoundingBoxes(frame: ARFrame) -> [BoundingBox] {
+        guard let depthMap = frame.sceneDepth?.depthMap else {
+            return []
+        }
+        _ = depthMap
+        // TODO: Run the DepthAnythingV2 model and fuse with LiDAR for 3D boxes.
+        return []
+    }
+}
+

--- a/src/RosControllerViewProvider.swift
+++ b/src/RosControllerViewProvider.swift
@@ -44,6 +44,7 @@ final class RosControllerViewProvider {
     private var transformsEntry: PubEntry! = nil
     private var depthEntry: PubEntry! = nil
     private var pointCloudEntry: PubEntry! = nil
+    private var boundingBoxEntry: PubEntry! = nil
     private var cameraEntry: PubEntry! = nil
     
     private let session: ARSession
@@ -62,12 +63,14 @@ final class RosControllerViewProvider {
         self.transformsEntry = self.createPubEntry(pubType: .transforms, labelText: "Transforms")
         self.depthEntry = self.createPubEntry(pubType: .depth, labelText: "Depth map", defaultTopicName: "/ipad/depth")
         self.pointCloudEntry = self.createPubEntry(pubType: .pointCloud, labelText: "Point cloud", defaultTopicName: "/ipad/pointcloud")
+        self.boundingBoxEntry = self.createPubEntry(pubType: .boundingBoxes, labelText: "Bounding boxes", defaultTopicName: "/ipad/bounding_boxes")
         self.cameraEntry = self.createPubEntry(pubType: .camera, labelText: "Camera", defaultTopicName: "/ipad/camera")
         
         self.pubEntries = [
             .transforms: self.transformsEntry,
             .depth: self.depthEntry,
             .pointCloud: self.pointCloudEntry,
+            .boundingBoxes: self.boundingBoxEntry,
             .camera: self.cameraEntry,
         ]
         self.pubEntries.forEach { (_: PubController.PubType, pubEntry: PubEntry) in
@@ -79,11 +82,11 @@ final class RosControllerViewProvider {
         
         // Stack with all the ROS config
         // TODO add separator between IP address and pub controls
-        let labelsStackView = self.createVerticalStack(arrangedSubviews: [urlTextFieldLabel, self.transformsEntry.label, self.depthEntry.label, self.pointCloudEntry.label, self.cameraEntry.label])
-        let textFieldsStackView = self.createVerticalStack(arrangedSubviews: [urlTextField, UIView(), self.depthEntry.topicNameField!, self.pointCloudEntry.topicNameField!, self.cameraEntry.topicNameField!])
-        let statusSwitchesView = self.createVerticalStack(arrangedSubviews: [masterSwitch, self.transformsEntry.stateSwitch, self.depthEntry.stateSwitch, self.pointCloudEntry.stateSwitch, self.cameraEntry.stateSwitch])
-        let steppersView = self.createVerticalStack(arrangedSubviews: [UIView(), self.transformsEntry.rateStepper, self.depthEntry.rateStepper, self.pointCloudEntry.rateStepper, self.cameraEntry.rateStepper])
-        let stepperDisplaysView = self.createVerticalStack(arrangedSubviews: [UIView(), self.transformsEntry.rateStepperLabel, self.depthEntry.rateStepperLabel, self.pointCloudEntry.rateStepperLabel, self.cameraEntry.rateStepperLabel])
+        let labelsStackView = self.createVerticalStack(arrangedSubviews: [urlTextFieldLabel, self.transformsEntry.label, self.depthEntry.label, self.pointCloudEntry.label, self.boundingBoxEntry.label, self.cameraEntry.label])
+        let textFieldsStackView = self.createVerticalStack(arrangedSubviews: [urlTextField, UIView(), self.depthEntry.topicNameField!, self.pointCloudEntry.topicNameField!, self.boundingBoxEntry.topicNameField!, self.cameraEntry.topicNameField!])
+        let statusSwitchesView = self.createVerticalStack(arrangedSubviews: [masterSwitch, self.transformsEntry.stateSwitch, self.depthEntry.stateSwitch, self.pointCloudEntry.stateSwitch, self.boundingBoxEntry.stateSwitch, self.cameraEntry.stateSwitch])
+        let steppersView = self.createVerticalStack(arrangedSubviews: [UIView(), self.transformsEntry.rateStepper, self.depthEntry.rateStepper, self.pointCloudEntry.rateStepper, self.boundingBoxEntry.rateStepper, self.cameraEntry.rateStepper])
+        let stepperDisplaysView = self.createVerticalStack(arrangedSubviews: [UIView(), self.transformsEntry.rateStepperLabel, self.depthEntry.rateStepperLabel, self.pointCloudEntry.rateStepperLabel, self.boundingBoxEntry.rateStepperLabel, self.cameraEntry.rateStepperLabel])
         let rosStackView = UIStackView(arrangedSubviews: [labelsStackView, textFieldsStackView, statusSwitchesView, steppersView, stepperDisplaysView])
         rosStackView.translatesAutoresizingMaskIntoConstraints = false
         rosStackView.axis = .horizontal
@@ -149,6 +152,8 @@ final class RosControllerViewProvider {
             self.updatePubTopic(.depth)
         case self.pointCloudEntry.topicNameField:
             self.updatePubTopic(.pointCloud)
+        case self.boundingBoxEntry.topicNameField:
+            self.updatePubTopic(.boundingBoxes)
         case self.cameraEntry.topicNameField:
             self.updatePubTopic(.camera)
         default:
@@ -167,6 +172,8 @@ final class RosControllerViewProvider {
             self.updateTopicState(.depth)
         case self.pointCloudEntry.stateSwitch:
             self.updateTopicState(.pointCloud)
+        case self.boundingBoxEntry.stateSwitch:
+            self.updateTopicState(.boundingBoxes)
         case self.cameraEntry.stateSwitch:
             self.updateTopicState(.camera)
         default:
@@ -183,6 +190,8 @@ final class RosControllerViewProvider {
             self.updateRate(.depth)
         case self.pointCloudEntry.rateStepper:
             self.updateRate(.pointCloud)
+        case self.boundingBoxEntry.rateStepper:
+            self.updateRate(.boundingBoxes)
         case self.cameraEntry.rateStepper:
             self.updateRate(.camera)
         default:

--- a/src/ros/PubController.swift
+++ b/src/ros/PubController.swift
@@ -24,6 +24,7 @@ final class PubController {
         case depth
         case pointCloud
         case camera
+        case boundingBoxes
     }
     public static let defaultRate = 10.0
     
@@ -43,7 +44,8 @@ final class PubController {
             .transforms: 15.0,
             .depth: PubController.defaultRate,
             .pointCloud: PubController.defaultRate,
-            .camera: PubController.defaultRate
+            .camera: PubController.defaultRate,
+            .boundingBoxes: PubController.defaultRate
         ]
     }
     

--- a/src/ros/PubManager.swift
+++ b/src/ros/PubManager.swift
@@ -31,6 +31,10 @@ final class PubManager {
     private var pubDepth: ControlledPublisher
     private var pubPointCloud: ControlledPublisher
     private var pubCamera: ControlledPublisher
+    private var pubBoundingBoxes: ControlledPublisher
+
+    private let boundingBoxDetector = BoundingBoxDetector()
+
     
     public init() {
         /// Create controlled pub objects for all publishers
@@ -40,6 +44,7 @@ final class PubManager {
         self.pubDepth = ControlledPublisher(interface: self.interface, type: sensor_msgs__Image.self)
         self.pubPointCloud = ControlledPublisher(interface: self.interface, type: sensor_msgs__PointCloud2.self)
         self.pubCamera = ControlledPublisher(interface: self.interface, type: sensor_msgs__Image.self)
+        self.pubBoundingBoxes = ControlledPublisher(interface: self.interface, type: lidar2ros__BoundingBox3DArray.self)
         
         let controlledPubs: [PubController.PubType: [ControlledPublisher]] = [
             //.transforms: [self.pubTf, self.pubTfStatic],
@@ -47,6 +52,7 @@ final class PubManager {
             .depth: [self.pubDepth],
             .pointCloud: [self.pubPointCloud],
             .camera: [self.pubCamera],
+            .boundingBoxes: [self.pubBoundingBoxes],
         ]
         self.pubController = PubController(pubs: controlledPubs, interface: self.interface)
     }
@@ -79,6 +85,7 @@ final class PubManager {
         self.startPubThread(id: "tf", pubType: .transforms, publishFunc: self.publishTf)
         self.startPubThread(id: "depth", pubType: .depth, publishFunc: self.publishDepth)
         self.startPubThread(id: "pointcloud", pubType: .pointCloud, publishFunc: self.publishPointCloud)
+        self.startPubThread(id: "bounding_boxes", pubType: .boundingBoxes, publishFunc: self.publishBoundingBoxes)
         // TODO fix/implement
         // self.startPubThread(id: "camera", pubType: .camera, publishFunc: self.publishCamera)
     }
@@ -116,6 +123,17 @@ final class PubManager {
         self.pubPointCloud.publish(RosMessagesUtils.pointsToPointCloud2(time: timestamp, points: pointCloud))
     }
     
+    private func publishBoundingBoxes() {
+        guard let currentFrame = self.session.currentFrame else {
+            return
+        }
+        let timestamp = currentFrame.timestamp
+        let boxes = self.boundingBoxDetector.detectBoundingBoxes(frame: currentFrame)
+        let msg = RosMessagesUtils.boundingBoxesToMsg(time: timestamp, boxes: boxes)
+        self.pubBoundingBoxes.publish(msg)
+    }
+
+
 //    private func publishCamera() {
 //        guard let currentFrame = self.session.currentFrame else {
 //            return

--- a/src/ros/msg/RosMessages.swift
+++ b/src/ros/msg/RosMessages.swift
@@ -118,3 +118,18 @@ struct geometry_msgs__TransformStamped: RosMsg {
 struct tf2_msgs__TFMessage: RosMsg {
     var transforms: [geometry_msgs__TransformStamped]
 }
+
+/// lidar2ros/BoundingBox3D
+struct lidar2ros__BoundingBox3D: RosMsg {
+    var header: std_msgs__Header
+    var center: geometry_msgs__Vector3
+    var size: geometry_msgs__Vector3
+    var orientation: geometry_msgs__Quaternion
+}
+
+/// lidar2ros/BoundingBox3DArray
+struct lidar2ros__BoundingBox3DArray: RosMsg {
+    var header: std_msgs__Header
+    var boxes: [lidar2ros__BoundingBox3D]
+}
+

--- a/src/ros/msg/RosMessagesUtils.swift
+++ b/src/ros/msg/RosMessagesUtils.swift
@@ -143,6 +143,18 @@ final class RosMessagesUtils {
         let tfIpad = self.transformStampedFromTf(self.arkitReferenceInverse, time: time, frame_id: "ipad_camera", child_frame_id: "ipad")
         return tf2_msgs__TFMessage(transforms: [tfArkitRef, tfIpad])
     }
+    // Convert array of BoundingBox to a ROS message.
+    public static func boundingBoxesToMsg(time: Double, boxes: [BoundingBox]) -> lidar2ros__BoundingBox3DArray {
+        let header = std_msgs__Header(stamp: self.getTimestamp(time), frame_id: "ipad")
+        let msgs = boxes.map { box -> lidar2ros__BoundingBox3D in
+            let center = geometry_msgs__Vector3(x: Float64(box.center.x), y: Float64(box.center.y), z: Float64(box.center.z))
+            let size = geometry_msgs__Vector3(x: Float64(box.size.x), y: Float64(box.size.y), z: Float64(box.size.z))
+            let ori = geometry_msgs__Quaternion(x: Float64(box.orientation.vector.x), y: Float64(box.orientation.vector.y), z: Float64(box.orientation.vector.z), w: Float64(box.orientation.vector.w))
+            return lidar2ros__BoundingBox3D(header: header, center: center, size: size, orientation: ori)
+        }
+        return lidar2ros__BoundingBox3DArray(header: header, boxes: msgs)
+    }
+
     
     /// Get TransformStamped message given various parameters.
     private static func transformStampedFromTf(_ tf: simd_float4x4, time: Double, frame_id: String, child_frame_id: String) -> geometry_msgs__TransformStamped {


### PR DESCRIPTION
## Summary
- integrate placeholder DepthAnythingV2 CoreML detector and publish 3D bounding boxes
- add ROS messages and utilities for `BoundingBox3D` arrays
- document new `/ipad/bounding_boxes` topic and enable UI controls for bounding boxes

## Testing
- `swift --version`
- `swift build` *(fails: Could not find Package.swift)*
- `xcodebuild -version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d7fb00c3883328c8af0438cfab766